### PR TITLE
Stat leaders UI, Live Game Card, and Backend Game Endpoint

### DIFF
--- a/client/src/components/PlayerCard.tsx
+++ b/client/src/components/PlayerCard.tsx
@@ -1,0 +1,56 @@
+import React from "react";
+
+interface PlayerCardProps {
+  player: {
+    id: number;
+    name: string;
+    position: string;
+    home_runs: number;
+    batting_avg: number;
+    obp: number;
+    war: number;
+    ops?: number;
+    sprintSpeed?: number;
+    exitVelocity?: number;
+  };
+}
+
+export default function PlayerCard({ player }: PlayerCardProps) {
+  return (
+    <div className="bg-white rounded-xl shadow p-4 hover:shadow-lg transition-all">
+      <div className="mb-2">
+        <h3 className="text-lg font-bold text-slate-800">{player.name}</h3>
+        <p className="text-sm text-slate-500">Position: {player.position}</p>
+      </div>
+      <ul className="text-sm text-slate-600 space-y-1">
+        <li>
+          <strong>HR:</strong> {player.home_runs}
+        </li>
+        <li>
+          <strong>AVG:</strong> {player.batting_avg.toFixed(3)}
+        </li>
+        <li>
+          <strong>OBP:</strong> {player.obp.toFixed(3)}
+        </li>
+        <li>
+          <strong>WAR:</strong> {player.war.toFixed(1)}
+        </li>
+        {player.ops !== undefined && (
+          <li>
+            <strong>OPS:</strong> {player.ops.toFixed(3)}
+          </li>
+        )}
+        {player.sprintSpeed !== undefined && (
+          <li>
+            <strong>Speed:</strong> {player.sprintSpeed.toFixed(1)} ft/s
+          </li>
+        )}
+        {player.exitVelocity !== undefined && (
+          <li>
+            <strong>Exit Velo:</strong> {player.exitVelocity.toFixed(1)} mph
+          </li>
+        )}
+      </ul>
+    </div>
+  );
+}

--- a/client/src/components/RosterGrid.tsx
+++ b/client/src/components/RosterGrid.tsx
@@ -1,0 +1,85 @@
+import React, { useState } from "react";
+import { motion, AnimatePresence } from "framer-motion";
+
+interface Player {
+  id: number;
+  name: string;
+  position: string;
+  home_runs: number;
+  batting_avg: number;
+  obp: number;
+  war: number;
+  ops?: number;
+  sprintSpeed?: number;
+  exitVelocity?: number;
+}
+
+interface RosterGridProps {
+  players: Player[];
+}
+
+import PlayerCard from "./PlayerCard";
+
+export default function RosterGrid({ players }: RosterGridProps) {
+  const [search, setSearch] = useState("");
+  const [sortKey, setSortKey] = useState<
+    "home_runs" | "war" | "batting_avg" | "ops" | "sprintSpeed" | "exitVelocity"
+  >("home_runs");
+
+  const filtered = players
+    .filter((p) => p.name.toLowerCase().includes(search.toLowerCase()))
+    .sort((a, b) => (b[sortKey] ?? 0) - (a[sortKey] ?? 0));
+
+  return (
+    <div>
+      <h2 className="text-2xl font-bold text-slate-800 mb-4">Roster</h2>
+
+      <div className="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-4 mb-6">
+        <input
+          type="text"
+          placeholder="Search players..."
+          value={search}
+          onChange={(e) => setSearch(e.target.value)}
+          className="w-full sm:max-w-xs p-3 border border-slate-300 rounded-xl shadow-sm focus:outline-none focus:ring-2 focus:ring-indigo-500"
+        />
+
+        <select
+          value={sortKey}
+          onChange={(e) => setSortKey(e.target.value as any)}
+          className="p-3 border border-slate-300 rounded-xl shadow-sm focus:outline-none focus:ring-2 focus:ring-indigo-500"
+        >
+          <option value="home_runs">Sort by Home Runs</option>
+          <option value="war">Sort by WAR</option>
+          <option value="batting_avg">Sort by Batting Avg</option>
+          <option value="ops">Sort by OPS</option>
+          <option value="sprintSpeed">Sort by Sprint Speed</option>
+          <option value="exitVelocity">Sort by Exit Velocity</option>
+        </select>
+      </div>
+
+      {filtered.length === 0 ? (
+        <p className="text-center text-slate-500">No players found.</p>
+      ) : (
+        <AnimatePresence mode="popLayout">
+          <motion.div
+            layout
+            className="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 lg:grid-cols-4 xl:grid-cols-5 2xl:grid-cols-6 gap-6"
+          >
+            {filtered.map((player) => (
+              <motion.div
+                key={player.id}
+                layout
+                initial={{ opacity: 0, scale: 0.95 }}
+                animate={{ opacity: 1, scale: 1 }}
+                exit={{ opacity: 0, scale: 0.95 }}
+                transition={{ duration: 0.2 }}
+              >
+                <PlayerCard player={player} />
+              </motion.div>
+            ))}
+          </motion.div>
+        </AnimatePresence>
+      )}
+    </div>
+  );
+}

--- a/client/src/components/StatCard.tsx
+++ b/client/src/components/StatCard.tsx
@@ -1,0 +1,34 @@
+interface StatCardProps {
+  name: string;
+  image?: string;
+  statLines: string[];
+  theme?: "blue" | "red" | "slate"; 
+}
+
+export default function StatCard({ name, image, statLines, theme = "blue" }: StatCardProps) {
+  const bg = {
+    red: "bg-red-600",
+    blue: "bg-blue-600",
+    slate: "bg-slate-600",
+  }[theme];
+
+  return (
+    <div className={`${bg} text-white rounded-xl shadow-lg p-6 flex items-center gap-4`}>
+      {image && (
+        <img
+          src={image}
+          alt={name}
+          className="w-16 h-16 rounded-full border-2 border-white object-cover"
+        />
+      )}
+      <div>
+        <h3 className="text-xl font-bold">{name}</h3>
+        <ul className="text-sm mt-1 space-y-1">
+          {statLines.map((line, i) => (
+            <li key={i}>{line}</li>
+          ))}
+        </ul>
+      </div>
+    </div>
+  );
+}

--- a/client/src/components/StatLeadersRow.tsx
+++ b/client/src/components/StatLeadersRow.tsx
@@ -1,0 +1,49 @@
+import React from "react";
+
+interface Player {
+  id: number;
+  name: string;
+  war?: number;
+  ops?: number;
+  sprintSpeed?: number;
+  exitVelocity?: number;
+}
+
+interface StatLeadersRowProps {
+  players: Player[];
+}
+
+const getLeader = (players: Player[], stat: keyof Player) => {
+  return players.reduce((top, curr) => {
+    return (curr[stat] ?? -Infinity) > (top[stat] ?? -Infinity) ? curr : top;
+  }, players[0]);
+};
+
+export default function StatLeadersRow({ players }: StatLeadersRowProps) {
+  const stats: { label: string; key: keyof Player }[] = [
+    { label: "WAR", key: "war" },
+    { label: "OPS", key: "ops" },
+    { label: "Sprint Speed", key: "sprintSpeed" },
+    { label: "Exit Velocity", key: "exitVelocity" },
+  ];
+
+  return (
+    <div className="grid grid-cols-2 sm:grid-cols-4 gap-4 mb-8">
+      {stats.map(({ label, key }) => {
+        const leader = getLeader(players, key);
+        return (
+          <div
+            key={key as string}
+            className="bg-white rounded-xl p-4 shadow-md border border-slate-200 text-center"
+          >
+            <h4 className="text-sm text-slate-500 font-medium mb-1">Top {label}</h4>
+            <p className="text-lg font-semibold text-slate-800">{leader.name}</p>
+            <p className="text-slate-600 text-sm">
+              {label}: {leader[key] ?? "N/A"}
+            </p>
+          </div>
+        );
+      })}
+    </div>
+  );
+}

--- a/client/src/components/StatsCards/LeaderLarge.tsx
+++ b/client/src/components/StatsCards/LeaderLarge.tsx
@@ -1,0 +1,40 @@
+import React, { useEffect, useState } from "react";
+
+interface LeaderLargeProps {
+  players: Array<{
+    name: string;
+    home_runs: number;
+    image?: string;
+  }>;
+}
+
+export default function LeaderLarge({ players }: LeaderLargeProps) {
+  const [leader, setLeader] = useState<LeaderLargeProps["players"][0] | null>(null);
+
+  useEffect(() => {
+    if (players.length === 0) return;
+    const topHR = [...players].sort((a, b) => b.home_runs - a.home_runs)[0];
+    setLeader(topHR);
+  }, [players]);
+
+  if (!leader) return null;
+
+  return (
+    <div className="bg-white rounded-2xl shadow-lg p-6 flex items-center gap-6">
+      <img
+        src={leader.image || "/images/default.png"}
+        alt={leader.name}
+        className="w-32 h-32 object-cover rounded-full border-4 border-indigo-500"
+      />
+      <div>
+        <h3 className="text-2xl font-bold text-slate-800 mb-1">
+          {leader.name}
+        </h3>
+        <p className="text-xl text-indigo-600 font-semibold">
+          {leader.home_runs} HR
+        </p>
+        <p className="text-slate-500 mt-1">Home Run Leader</p>
+      </div>
+    </div>
+  );
+}

--- a/client/src/components/StatsCards/LeaderSmall.tsx
+++ b/client/src/components/StatsCards/LeaderSmall.tsx
@@ -1,0 +1,23 @@
+import React from "react";
+
+interface LeaderSmallProps {
+  players: Array<{ name: string; value: number; unit?: string }>;
+  statLabel: string;
+}
+
+export default function LeaderSmall({ players, statLabel }: LeaderSmallProps) {
+  if (!players || players.length === 0) return null;
+
+  const top = [...players].filter(p => p.value !== undefined && !isNaN(p.value)).sort((a, b) => b.value - a.value)[0];
+  if (!top) return null;
+
+  const formattedValue = top.unit ? `${top.value} ${top.unit}` : top.value;
+
+  return (
+    <div className="bg-white rounded-xl shadow-md p-4 text-center">
+      <h4 className="text-slate-600 text-sm font-medium mb-1">{statLabel}</h4>
+      <p className="text-xl font-bold text-indigo-700">{formattedValue}</p>
+      <p className="text-xs text-slate-500 mt-1">{top.name}</p>
+    </div>
+  );
+}

--- a/client/src/components/ToggleTeam.tsx
+++ b/client/src/components/ToggleTeam.tsx
@@ -1,0 +1,34 @@
+import React from "react";
+
+interface ToggleTeamProps {
+  current: "yankees" | "mlb";
+  onToggle: (view: "yankees" | "mlb") => void;
+}
+
+export default function ToggleTeam({ current, onToggle }: ToggleTeamProps) {
+  return (
+    <div className="flex justify-center gap-4">
+      <button
+        onClick={() => onToggle("yankees")}
+        className={`px-6 py-2 rounded-full font-semibold transition-all shadow-sm ${
+          current === "yankees"
+            ? "bg-indigo-600 text-white"
+            : "bg-white text-slate-600 border border-slate-300"
+        }`}
+      >
+        My Team (Yankees)
+      </button>
+
+      <button
+        onClick={() => onToggle("mlb")}
+        className={`px-6 py-2 rounded-full font-semibold transition-all shadow-sm ${
+          current === "mlb"
+            ? "bg-indigo-600 text-white"
+            : "bg-white text-slate-600 border border-slate-300"
+        }`}
+      >
+        All MLB
+      </button>
+    </div>
+  );
+}

--- a/client/src/components/TrendingCard.tsx
+++ b/client/src/components/TrendingCard.tsx
@@ -1,0 +1,30 @@
+import React from "react";
+
+interface TrendingCardProps {
+  name: string;
+  statLines: string[];
+  color?: "blue" | "red" | "slate";
+  image?: string;
+}
+
+export default function TrendingCard({ name, statLines, color = "blue", image }: TrendingCardProps) {
+  const bgColor = {
+    blue: "bg-blue-600",
+    red: "bg-red-600",
+    slate: "bg-slate-600",
+  }[color];
+
+  return (
+    <div className={`${bgColor} text-white rounded-xl p-4 flex items-center gap-4 shadow-md`}>
+      {image && <img src={image} alt={name} className="w-16 h-16 rounded-full border border-white" />}
+      <div>
+        <h4 className="text-lg font-bold">{name}</h4>
+        <ul className="text-sm mt-1 space-y-1">
+          {statLines.map((line, i) => (
+            <li key={i}>{line}</li>
+          ))}
+        </ul>
+      </div>
+    </div>
+  );
+}

--- a/server/src/routes/mlb.ts
+++ b/server/src/routes/mlb.ts
@@ -1,9 +1,12 @@
 import express from 'express';
-import { getPlayerStats, getYankeesRoster } from '../controllers/mlbController';
+import { getPlayerStats, getFullRosterWithStats, getYankeesGame  } from '../controllers/mlbController';
+
+
 
 const router = express.Router();
 
 router.get('/player', getPlayerStats);
-router.get('/roster', getYankeesRoster);
+router.get('/yankees-game', getYankeesGame);
+router.get("/roster", getFullRosterWithStats);
 
 export default router;


### PR DESCRIPTION
### Summary

This PR adds multiple new features and infrastructure updates:

- 🧢 Live Yankees game card component with real-time API integration
- 📊 Stat card and trending card UI components
- 🔄 Backend endpoint for live game status and player comparison
- 📈 Setup for stat leader row and pitching/offensive charts
- 📝 New README.md with setup instructions, feature list, and roadmap

### Why

This begins the first major feature push for the YankeeScope dashboard, giving it real utility and visuals while preparing the backend for more advanced analytics.

---

✅ Ready for merge into `main`
